### PR TITLE
Friends List Render

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -1,6 +1,8 @@
 import React from "react"
 import { Route } from "react-router-dom"
 import { Home } from "./Home"
+import { FriendProvider } from "./friends/FriendProvider"
+import { FriendList } from "./friends/FriendList"
 
 export const ApplicationViews = (props) => {
     return (
@@ -8,6 +10,13 @@ export const ApplicationViews = (props) => {
             <Route exact path="/">
                 <Home />
             </Route>
+
+            <FriendProvider>
+                <Route exact path="/friends">
+                    <FriendList />
+                </Route>
+            </FriendProvider>
+
         </>
     )
 }

--- a/src/components/friends/FriendCard.js
+++ b/src/components/friends/FriendCard.js
@@ -1,6 +1,7 @@
 import React from "react"
 import { Link } from "react-router-dom"
 
+//creates html for each friend, which can be clicked to view the details of that friend
 export const FriendCard = ({ friend }) => (
     <section className="friend">
         <h3 className="friend__name">

--- a/src/components/friends/FriendCard.js
+++ b/src/components/friends/FriendCard.js
@@ -1,0 +1,12 @@
+import React from "react"
+import { Link } from "react-router-dom"
+
+export const FriendCard = ({ friend }) => (
+    <section className="friend">
+        <h3 className="friend__name">
+            <Link to={`/friends/detail/${friend.userId}`}>
+                { friend.user.name }
+            </Link>
+        </h3>
+    </section>
+)

--- a/src/components/friends/FriendList.js
+++ b/src/components/friends/FriendList.js
@@ -3,22 +3,23 @@ import { FriendContext } from "./FriendProvider"
 import { FriendCard } from "./FriendCard"
 
 export const FriendList = () => {
-   // This state changes when `getFriends()` is invoked below
-    const { friends, getFriends } = useContext(FriendContext)
+  // This state changes when `getFriends()` is invoked below
+  const { friends, getFriends } = useContext(FriendContext)
 	
 	//useEffect - reach out to the world for something
-    useEffect(() => {
-		getFriends()
-    }, [])
+  useEffect(() => {
+	  getFriends()
+  }, [])
 
-    return (
-        <div className="friends">
-            <h2>Your Friends</h2>
-            {
-          friends.map(friend => {
-            return <FriendCard key={friend.id} friend={friend} />
-          })
-            }
-        </div>
-    )
+  //returns the user's list of friends
+  return (
+    <div className="friends">
+      <h2>Your Friends</h2>
+      {
+        friends.map(friend => {
+          return <FriendCard key={friend.id} friend={friend} />
+        })
+      }
+    </div>
+  )
 }

--- a/src/components/friends/FriendList.js
+++ b/src/components/friends/FriendList.js
@@ -1,0 +1,24 @@
+import React, { useContext, useEffect } from "react"
+import { FriendContext } from "./FriendProvider"
+import { FriendCard } from "./FriendCard"
+
+export const FriendList = () => {
+   // This state changes when `getFriends()` is invoked below
+    const { friends, getFriends } = useContext(FriendContext)
+	
+	//useEffect - reach out to the world for something
+    useEffect(() => {
+		getFriends()
+    }, [])
+
+    return (
+        <div className="friends">
+            <h2>Your Friends</h2>
+            {
+          friends.map(friend => {
+            return <FriendCard key={friend.id} friend={friend} />
+          })
+            }
+        </div>
+    )
+}

--- a/src/components/friends/FriendProvider.js
+++ b/src/components/friends/FriendProvider.js
@@ -13,12 +13,15 @@ export const FriendProvider = (props) => {
     const [friends, setFriends] = useState([])
     const userId = localStorage.getItem("slasherUser")
 
+    //gets all friend relationships where friendUserId is the current logged in user
+    //userId in the returned objects is expanded to show the friend(user)'s info
     const getFriends = () => {
         return fetch(`http://localhost:8088/friends?friendUserId=${userId}&_expand=user`)
             .then(res => res.json())
             .then(setFriends)
     }
 
+    //will be used for adding friends
     const addFriend = friendObj => {
         return fetch("http://localhost:8088/friends", {
             method: "POST",
@@ -30,11 +33,13 @@ export const FriendProvider = (props) => {
             .then(getFriends)
     }
 
+    //will be used for viewing friend details and deleting friend relationships
     const getFriendById = (id) => {
         return fetch(`http://localhost:8088/friends?friendUserId=${userId}&userId=${id}&_expand=user`)
             .then(res => res.json())
     }
 
+    //will be used twice when deleting a friend relationship
     const deleteFriend = relationshipId => {
         return fetch(`http://localhost:8088/friends/${relationshipId}`, {
             method: "DELETE"

--- a/src/components/friends/FriendProvider.js
+++ b/src/components/friends/FriendProvider.js
@@ -1,0 +1,52 @@
+import React, { useState, createContext } from "react"
+
+/*
+    The context is imported and used by individual components
+    that need data
+*/
+export const FriendContext = createContext()
+
+/*
+ This component establishes what data can be used.
+ */
+export const FriendProvider = (props) => {
+    const [friends, setFriends] = useState([])
+    const userId = localStorage.getItem("slasherUser")
+
+    const getFriends = () => {
+        return fetch(`http://localhost:8088/friends?friendUserId=${userId}&_expand=user`)
+            .then(res => res.json())
+            .then(setFriends)
+    }
+
+    const addFriend = friendObj => {
+        return fetch("http://localhost:8088/friends", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify(friendObj)
+        })
+            .then(getFriends)
+    }
+
+    const getFriendById = (id) => {
+        return fetch(`http://localhost:8088/friends?friendUserId=${userId}&userId=${id}&_expand=user`)
+            .then(res => res.json())
+    }
+
+    const deleteFriend = relationshipId => {
+        return fetch(`http://localhost:8088/friends/${relationshipId}`, {
+            method: "DELETE"
+        })
+            .then(getFriends)
+    }
+
+    return (
+        <FriendContext.Provider value={{
+            friends, getFriends, addFriend, getFriendById, deleteFriend
+        }}>
+            {props.children}
+        </FriendContext.Provider>
+    )
+}


### PR DESCRIPTION
A user can now view friends that they have already added.

To test this feature, you will need to be hosting a local api with at least two users who have each other added.
(You need both friend objects where userId=1 and friendUserId=2 and vice versa)
Then navigate to the friend's page in the nav bar and verify that the current logged in user's friends render.